### PR TITLE
Prevents logger from emitting: 'No handlers could be found for logger mutagenerate'.

### DIFF
--- a/mutagenerate/log.py
+++ b/mutagenerate/log.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
-
 import logging
 
 logger = logging.getLogger("mutagenerate")
 logger.setLevel(logging.DEBUG)
+
+logger.addHandler(logging.NullHandler())

--- a/mutagenerate/log.py
+++ b/mutagenerate/log.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import logging
 
 logger = logging.getLogger("mutagenerate")


### PR DESCRIPTION
Prevents logger from emitting: 'No handlers could be found for logger mutagenerate'.

Very low priority fix.
